### PR TITLE
Use default credential chain if credentialsfile not specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ func isValidConfig(config Configs) bool {
 	valid = valid && config.WebConfigs.Port > 0
 	valid = valid && config.WebConfigs.Port < 65535
 	valid = valid && len(config.S3configs.BucketName) > 0
-	valid = valid && len(config.S3configs.CredentialsFile) > 0
 	valid = valid && len(config.S3configs.Region) > 0
 	return valid
 }

--- a/s3fetcher.go
+++ b/s3fetcher.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -20,9 +22,15 @@ type S3configs struct {
 // NewS3Fetcher is a S3 backed implementation of the FileFetcher interface.
 // it does the setup of the S3 service session state required to implement FileFetcher interface
 func NewS3Fetcher(cfg S3configs) FileFetcher {
-	svc := s3.New(session.New(
-		aws.NewConfig().WithRegion(cfg.Region).WithCredentials(
-			credentials.NewSharedCredentials(cfg.CredentialsFile, "default"))))
+	awsCfg := aws.NewConfig().WithRegion(cfg.Region)
+	if cfg.CredentialsFile != "" {
+		log.Printf("using AWS credentials from %s", cfg.CredentialsFile)
+		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials(cfg.CredentialsFile, "default"))
+	} else {
+		log.Print("no AWS credentials file specified, using the default credentials chain")
+	}
+
+	svc := s3.New(session.New(awsCfg))
 	cfg.s3svc = svc
 
 	return cfg


### PR DESCRIPTION
At the moment, credentials must come from the `credentialsfile` setting in the config file because the AWS SDK credentials chain has been replaced.

This means it isn't possible to use environment variables to specify the credentials at all, or from the instance/container IAM role if we ever decide to go down that road.

This change makes go-minipypi only replace the default credential chain if credentialfile is specified in the config. If not, then the default credential chain will be used, i.e. the order defined here - https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials