### PR TITLE
Log if LISTDIR operation fails

### DIFF
--- a/frontend.go
+++ b/frontend.go
@@ -76,6 +76,7 @@ func (ctx WebServerConfigs) handleListDir(w http.ResponseWriter, path string) {
 	fileList, err := handlePypiListDir(ctx.fetcher, path)
 	if err != nil {
 		desc := fmt.Sprintf("\"LISTDIR %v\" 400 - err: %v", path, err)
+		log.Println(desc)
 		http.Error(w, desc, http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Currently if a LISTDIR operation is requested but fails, there's no mention of it in the logs - the only way to know is through the response content, which is silently swallowed by pip.