### PR TITLE
Use Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/citymapper/go-minipypi
+
+require (
+	github.com/aws/aws-sdk-go v1.16.1
+	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/aws/aws-sdk-go v1.16.1 h1:x/KXjZHqwEXjW9i83HgvV17G3cxqSxZ21vzOzWF39Dg=
+github.com/aws/aws-sdk-go v1.16.1/go.mod h1:es1KtYUFs7le0xQ3rOihkuoVD90z7D0fR2Qm4S00/gU=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This supercedes #11 by using the new Go modules system instead.