### PR TITLE
update go image to latest (1.17)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: cimg/go:1.17
     working_directory: /home/circleci/citymapper/go-minipypi
     environment:
       TEST_RESULTS: &test_results /tmp/test-results


### PR DESCRIPTION
Trying to fix the build, and it fails due to go mod. I have limited knowledge of latest go versions, but it seems updating the go version to latest works 🤷 